### PR TITLE
Fix getPeerCertificates() method to return the right peer certificates

### DIFF
--- a/src/main/java/com/aliyun/gmsse/GMSSLSession.java
+++ b/src/main/java/com/aliyun/gmsse/GMSSLSession.java
@@ -18,6 +18,7 @@ public class GMSSLSession implements SSLSession {
     SessionContext sessionContext;
     ID sessionId;
     public String peerHost;
+	public int peerPort;
     public KeyManager keyManager;
     public TrustManager trustManager;
     public SecureRandom random;
@@ -74,14 +75,12 @@ public class GMSSLSession implements SSLSession {
 
     @Override
     public String getPeerHost() {
-        // TODO Auto-generated method stub
-        return null;
+        return peerHost;
     }
 
     @Override
     public int getPeerPort() {
-        // TODO Auto-generated method stub
-        return 0;
+        return peerPort;
     }
 
     @Override

--- a/src/main/java/com/aliyun/gmsse/GMSSLSession.java
+++ b/src/main/java/com/aliyun/gmsse/GMSSLSession.java
@@ -103,8 +103,7 @@ public class GMSSLSession implements SSLSession {
 
     @Override
     public Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
-        // TODO Auto-generated method stub
-        return null;
+        return peerCerts;
     }
 
     @Override

--- a/src/main/java/com/aliyun/gmsse/GMSSLSocket.java
+++ b/src/main/java/com/aliyun/gmsse/GMSSLSocket.java
@@ -417,6 +417,7 @@ public class GMSSLSocket extends SSLSocket {
         // TODO: process the compresion method
         session.cipherSuite = sh.getCipherSuite();
         session.peerHost = remoteHost;
+        session.peerPort = port;
         session.sessionId = new GMSSLSession.ID(sh.getSessionId());
         handshakes.add(hsf);
         securityParameters.serverRandom = sh.getRandom();


### PR DESCRIPTION
Fix getPeerCertificates() and getPeerHost() and getPeerPort() methods which have failed to return the right values.