### PR TITLE
fix: 修复客户端CertificateVerify消息未签名导致decrypt_error错误

### DIFF
--- a/src/main/java/com/aliyun/gmsse/protocol/ClientConnectionContext.java
+++ b/src/main/java/com/aliyun/gmsse/protocol/ClientConnectionContext.java
@@ -3,6 +3,7 @@ package com.aliyun.gmsse.protocol;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import javax.net.ssl.X509KeyManager;
 
 import org.bouncycastle.crypto.engines.SM4Engine;
 import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 
 import com.aliyun.gmsse.AlertException;
@@ -182,7 +184,10 @@ public class ClientConnectionContext extends ConnectionContext {
         for (Handshake handshake : handshakes) {
             out.write(handshake.getBytes());
         }
-        byte[] signature = Crypto.hash(out.toByteArray());
+        // byte[] signature = Crypto.hash(out.toByteArray());
+        byte[] source = Crypto.hash(out.toByteArray());
+        PrivateKey key = sslContext.getKeyManager().getPrivateKey("sign");
+        byte[] signature = Crypto.sign((BCECPrivateKey) key,null,source);
         CertificateVerify cv = new CertificateVerify(signature);
         Handshake hs = new Handshake(Handshake.Type.CERTIFICATE_VERIFY, cv);
         Record rc = new Record(ContentType.HANDSHAKE, version, hs.getBytes());

--- a/src/main/java/com/aliyun/gmsse/protocol/ServerConnectionContext.java
+++ b/src/main/java/com/aliyun/gmsse/protocol/ServerConnectionContext.java
@@ -19,6 +19,7 @@ import javax.security.auth.x500.X500Principal;
 import org.bouncycastle.crypto.engines.SM4Engine;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 import org.bouncycastle.jcajce.spec.SM2ParameterSpec;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
@@ -123,8 +124,15 @@ public class ServerConnectionContext extends ConnectionContext {
         for (Handshake handshake : handshakes) {
             out.write(handshake.getBytes());
         }
-        byte[] signature = Crypto.hash(out.toByteArray());
-        if (!Arrays.equals(signature, cv.getSignature())) {
+        // byte[] signature = Crypto.hash(out.toByteArray());
+        // if (!Arrays.equals(signature, cv.getSignature())) {
+        //     throw new SSLException("certificate verify failed");
+        // }
+        X509Certificate signCert = session.peerCerts[0];
+        byte[] source = Crypto.hash(out.toByteArray());
+        boolean flag = Crypto.verify((BCECPublicKey)signCert.getPublicKey(),null,source,
+                cv.getSignature());
+        if (!flag) {
             throw new SSLException("certificate verify failed");
         }
         handshakes.add(cf);


### PR DESCRIPTION
#71 #73
fix: 修复客户端CertificateVerify消息未签名导致decrypt_error错误